### PR TITLE
Remove watcher if the layer it's associated with has been removed (fixes https://github.com/evetion/Reloader/issues/5)

### DIFF
--- a/reloader.py
+++ b/reloader.py
@@ -63,9 +63,6 @@ from .resources import *
 import re
 import urllib.parse
 
-# Used to get callbacks working reliably
-from qgis.core import QgsProject
-
 # For logging
 from qgis.core import QgsMessageLog
 

--- a/reloader.py
+++ b/reloader.py
@@ -61,6 +61,9 @@ from .resources import *
 import re
 import urllib.parse
 
+# Used for callback
+from qgis.core import QgsProject
+
 # For logging
 from qgis.core import QgsMessageLog
 
@@ -295,11 +298,22 @@ class Reloader:
                 path = self.extract_path_from_uri(uri)
 
                 if not isfile(path):
+                    # Path doesn't specify an extant local file
+
+                    # Notify the user
                     self.iface.messageBar().pushMessage(
                         "Warning",
                         f"Can't watch {layer.name()} for updates because it is not a local path.",
                         level=Qgis.Warning,
                         duration=5,
+                    )
+
+                    # Also log it to the Reloader log
+                    QgsMessageLog.logMessage(
+                        f"Can't watch {layer.name()} for updates because it is not a local path.",
+                        tag="Reloader",
+                        level=Qgis.Warning,
+                        notifyUser=False,
                     )
 
                 else:
@@ -311,57 +325,60 @@ class Reloader:
                     )
 
                     # Callback to perform the refresh of the appropriate layer
+                    # This is called by watcher when a watched file changes.
+                    #
                     # path:     The file being watched
                     #           This is set by the watcher to the path of the
                     #           file whose change triggered the callback,
                     #           irrespective of what value was specified when
                     #           the callback was connected to the watcher.
-                    # layer:    The layer to be reloaded
                     # layer_id: The ID of the layer to be reloaded
                     #
-                    # Note: The "layer=layer" syntax used in the callback
-                    # definition explicitly sets the layer argument's value to
-                    # the current layer value at the time the callback is
-                    # created.  If one instead were to omit "layer=layer" then
-                    # the layer passed to the callback would be the value of the
-                    # watch(self) method's layer iterator at the time that the
-                    # callback is called, namely the final layer in the most-
-                    # recently added list of layers to watch.  In other words,
-                    # parameters to the callback function must be explicitly set
-                    # in the callback's definition (this does not apply to the
-                    # path parameter since its value is set by the watcher at
-                    # the time the callback is called).  The "layer_id" value 
-                    # is similarly set at the time the callback is created.
-                    # For further discussion of this see:
+                    # Note: The "layer_id=layer.id()" syntax used in the call-
+                    # back definition explicitly sets the layer_id argument's
+                    # value to the current layer's ID at the time the callback
+                    # is created.  If one were to omit "layer_id=layer.id()" 
+                    # and instead set layer_id in the watch() function's loop 
+                    # then the layer_id passed to the callback would be the 
+                    # layer_id value of the final iteration of the loop.  In 
+                    # other words, parameters to the callback function must be 
+                    # explicitly set in the callback's definition (this does 
+                    # not apply to the path parameter since its value is set by 
+                    # the watcher at the time the callback is called).  For 
+                    # further discussion of this see:
                     # http://jceipek.com/Olin-Coding-Tutorials/
-                    def reload_callback(path, layer=layer, layer_id=layer.id()):
+                    def reload_callback(path, layer_id=layer.id()):
 
-                        # Make sure the layer associated with the watcher still exists
-                        try:
-                            # Test whether underlying C/C++ object has been deleted
-                            dummy = layer.id()
-                        except RuntimeError:
-                            # Catch the exception thrown if a layer is being watched, the layer is deleted, 
-                            # and then the layer's watched file changes:
-                            # RuntimeError: wrapped C/C++ object of type QgsVectorLayer has been deleted 
+                        # Get the layer object for the relevant layer's ID
+                        # Returns None if no layer with the given ID exists
+                        layer = QgsProject.instance().mapLayer(layer_id)
+
+                        if layer is None:
+                            # Layer for given ID does not exist
+                            
+                            # Layer was being watched but the layer was deleted
+                            # and subsequently the layer's watched file changed
+                            
                             QgsMessageLog.logMessage(
                                 "Reloading layer\n" +
                                 "The layer for the watched file was deleted, removing its watcher\n" +
-                                f"Path: {path}",
+                                f"Layer ID: {layer_id}\n" +
+                                f"Path:     {path}",
                                 tag="Reloader",
                                 level=Qgis.Info,
                                 notifyUser=False,
                             )
+                            
                             # Get the watcher for this [removed] layer
                             watcher = self.watchers.pop(layer_id, None)
                             # Sanity check
                             if watcher is None:
                                 # Shouldn't happen
-                                self.iface.messageBar().pushMessage(
-                                    "Warning",
+                                QgsMessageLog.logMessage(
                                     "Can't stop watching the removed layer because we never started watching it!",
+                                    tag="Reloader",
                                     level=Qgis.Warning,
-                                    duration=5,
+                                    notifyUser=False,
                                 )
                             else:
                                 # Delete the removed layer's watcher


### PR DESCRIPTION
This code adds a check to `reload_callback` that verifies that the layer associated with the watcher still exists.  If the layer has been removed then its watcher is deleted and the rest of the callback is not run.

This code has been tested with several layers being watched and their files frequently updated.  After one of the layers is removed this code operates as designed with the removed layer's watcher being deleted and no effect being seen on the other [unrelated] watchers.

---

This is one approach to solving the issue.  Doing a check at callback time ensures that the callback's parameters (i.e. `layer`) are still valid.  What this code does not address is the leaking of a (presumably negligible) amount of memory for layers that have been removed but who watchers are never triggered.  Removing the watcher at layer removal time would require hooking in to the layer removal code, something that I don't know how to do (if it is even possible).  Even if such code were implemented having this code also be in place would be a good thing ("belt and braces").